### PR TITLE
Deprecate Gen-taking forAllNoShrink

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -548,35 +548,28 @@ object Prop {
 
   /** Universal quantifier for an explicit generator. Does not shrink failed
    *  test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
     pv: P => Prop,
     pp1: T1 => Pretty
-  ): Prop = Prop { prms0 =>
-    val (prms, seed) = startSeed(prms0)
-    val gr = g1.doApply(prms, seed)
-    gr.retrieve match {
-      case None => undecided(prms)
-      case Some(x) =>
-        val p = secure(f(x))
-        val labels = gr.labels.mkString(",")
-        provedToTrue(p(slideSeed(prms0))).addArg(Arg(labels,x,0,x,pp1(x),pp1(x)))
-    }
-  }
+  ): Prop = forAll(g1)(f)
 
   /** Universal quantifier for two explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,P](
     g1: Gen[T1], g2: Gen[T2])(
     f: (T1,T2) => P)(implicit
     p: P => Prop,
     pp1: T1 => Pretty,
     pp2: T2 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2)(f(t, _:T2)))
+  ): Prop = forAll(g1, g2)(f)
 
   /** Universal quantifier for three explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
     f: (T1,T2,T3) => P)(implicit
@@ -584,10 +577,11 @@ object Prop {
     pp1: T1 => Pretty,
     pp2: T2 => Pretty,
     pp3: T3 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3)(f(t, _:T2, _:T3)))
+  ): Prop = forAll(g1, g2, g3)(f)
 
   /** Universal quantifier for four explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,T4,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
     f: (T1,T2,T3,T4) => P)(implicit
@@ -596,10 +590,11 @@ object Prop {
     pp2: T2 => Pretty,
     pp3: T3 => Pretty,
     pp4: T4 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
+  ): Prop = forAll(g1, g2, g3, g4)(f)
 
   /** Universal quantifier for five explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,T4,T5,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
     f: (T1,T2,T3,T4,T5) => P)(implicit
@@ -609,10 +604,11 @@ object Prop {
     pp3: T3 => Pretty,
     pp4: T4 => Pretty,
     pp5: T5 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
+  ): Prop = forAll(g1, g2, g3, g4, g5)(f)
 
   /** Universal quantifier for six explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
     f: (T1,T2,T3,T4,T5,T6) => P)(implicit
@@ -623,10 +619,11 @@ object Prop {
     pp4: T4 => Pretty,
     pp5: T5 => Pretty,
     pp6: T6 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
+  ): Prop = forAll(g1, g2, g3, g4, g5, g6)(f)
 
   /** Universal quantifier for seven explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,T7,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
     f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
@@ -638,10 +635,11 @@ object Prop {
     pp5: T5 => Pretty,
     pp6: T6 => Pretty,
     pp7: T7 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
+  ): Prop = forAll(g1, g2, g3, g4, g5, g6, g7)(f)
 
   /** Universal quantifier for eight explicit generators.
    *  Does not shrink failed test cases. */
+  @deprecated("Use 'forAll'.  Here only for bincompat")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,T7,T8,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
     f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit
@@ -654,7 +652,7 @@ object Prop {
     pp6: T6 => Pretty,
     pp7: T7 => Pretty,
     pp8: T8 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
+  ): Prop = forAll(g1, g2, g3, g4, g5, g6, g7, g8)(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,P](
@@ -911,7 +909,17 @@ object Prop {
     f: T1 => P)(implicit
     p: P => Prop,
     pp1: T1 => Pretty
-  ): Prop = forAllNoShrink(g1)(f)
+  ): Prop = Prop { prms0 =>
+    val (prms, seed) = startSeed(prms0)
+    val gr = g1.doApply(prms, seed)
+    gr.retrieve match {
+      case None => undecided(prms)
+      case Some(x) =>
+        val p = secure(f(x))
+        val labels = gr.labels.mkString(",")
+        provedToTrue(p(slideSeed(prms0))).addArg(Arg(labels,x,0,x,pp1(x),pp1(x)))
+    }
+  }
 
   /** Universal quantifier for two explicit generators. */
   def forAll[T1,T2,P](
@@ -920,7 +928,7 @@ object Prop {
     p: P => Prop,
     pp1: T1 => Pretty,
     pp2: T2 => Pretty
-  ): Prop = forAllNoShrink(g1, g2)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2)(f(t, _:T2)))
 
   /** Universal quantifier for three explicit generators. */
   def forAll[T1,T2,T3,P](
@@ -930,7 +938,7 @@ object Prop {
     pp1: T1 => Pretty,
     pp2: T2 => Pretty,
     pp3: T3 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3)(f(t, _:T2, _:T3)))
 
   /** Universal quantifier for four explicit generators. */
   def forAll[T1,T2,T3,T4,P](
@@ -941,7 +949,7 @@ object Prop {
     pp2: T2 => Pretty,
     pp3: T3 => Pretty,
     pp4: T4 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3, g4)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
 
   /** Universal quantifier for five explicit generators. */
   def forAll[T1,T2,T3,T4,T5,P](
@@ -953,7 +961,7 @@ object Prop {
     pp3: T3 => Pretty,
     pp4: T4 => Pretty,
     pp5: T5 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
 
   /** Universal quantifier for six explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,P](
@@ -966,7 +974,7 @@ object Prop {
     pp4: T4 => Pretty,
     pp5: T5 => Pretty,
     pp6: T6 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
 
   /** Universal quantifier for seven explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,P](
@@ -980,7 +988,7 @@ object Prop {
     pp5: T5 => Pretty,
     pp6: T6 => Pretty,
     pp7: T7 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6, g7)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
 
   /** Universal quantifier for eight explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,T8,P](
@@ -995,7 +1003,7 @@ object Prop {
     pp6: T6 => Pretty,
     pp7: T7 => Pretty,
     pp8: T8 => Pretty
-  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6, g7, g8)(f)
+  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
 
   /** Converts a function into a universally quantified property */
   def forAll[A1,P] (


### PR DESCRIPTION
Swap the impls, so the deprecated API calls the not deprecated API.